### PR TITLE
Fix validation errors, add to admin

### DIFF
--- a/custom_reg_form/admin.py
+++ b/custom_reg_form/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
+from .models import ExtraInfo
 
-# Register your models here.
+admin.site.register(ExtraInfo)

--- a/custom_reg_form/forms.py
+++ b/custom_reg_form/forms.py
@@ -5,7 +5,12 @@ class ExtraInfoForm(ModelForm):
     """
     The fields on this form are derived from the ExtraInfo model in models.py.
     """
-    pass
+    def __init__(self, *args, **kwargs):
+        super(ExtraInfoForm, self).__init__(*args, **kwargs)
+        self.fields['favorite_movie'].error_messages = {
+            "required": u"Please tell us your favorite movie.",
+            "invalid": u"We're pretty sure you made that movie up.",
+        }
 
     class Meta(object):
         model = ExtraInfo

--- a/custom_reg_form/models.py
+++ b/custom_reg_form/models.py
@@ -15,16 +15,16 @@ class ExtraInfo(models.Model):
         ('vim', 'Vim'),
         ('emacs', 'Emacs'),
         ('np', 'Notepad'),
-        ('cat', 'cat > filename')
+        ('cat', 'cat > filename'),
     )
 
     favorite_movie = models.CharField(
-        verbose_name="Fav Flick", max_length=100, error_messages={
-            "required": u"Please tell us your favorite movie.",
-            "invalid": u"We're pretty sure you made that movie up."
-        }
+        verbose_name="Fav Flick",
+        max_length=100,
     )
     favorite_editor = models.CharField(
-        verbose_name="Favorite Editor", choices=FAVORITE_EDITOR, blank=True, 
-        max_length=5
+        verbose_name="Favorite Editor",
+        choices=FAVORITE_EDITOR,
+        blank=True, 
+        max_length=5,
     )


### PR DESCRIPTION
@Kelketek I found that `error_messages` was not being used (it just said "this field is required").

So this PR updates the example to have working `error_messages`, by moving it from the model to the form. See [this wontfix django bug](https://code.djangoproject.com/ticket/13693) for details.

I also made the new data show up in the admin, although not very well.
